### PR TITLE
Fix deprecation warnings

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -44,7 +44,7 @@
     cache_valid_time: 1800
 
 - name: Install docker-compose
-  when: docker_install_compose
+  when: docker_install_compose | bool
   apt:
     name:
       - docker-compose


### PR DESCRIPTION
The old syntax currently throws deprecation warnings, so I added a bool filter.